### PR TITLE
add reference test client and server for I2C.

### DIFF
--- a/i2c test client.py
+++ b/i2c test client.py
@@ -1,0 +1,67 @@
+'''Test client for custom I2C server.
+
+This client opens a raw I2C connection on address 42, and tries to send a single byte,
+then tries to receive a single byte.  If things end up working, the on-board neopixel
+should turn green.  Otherwise, it'll probably cycle back and forth between red and white.
+
+'''
+
+# derived from:
+# https://cdn-learn.adafruit.com/downloads/pdf/circuitpython-basics-i2c-and-spi.pdf
+
+ADDRESS = 0x42
+
+import board, time
+
+import neopixel
+led = neopixel.NeoPixel(board.NEOPIXEL, 1)
+led.brightness = 0.3
+def set(r, g, b): led[0] = (r, g, b)
+
+
+# To use default I2C bus (most boards)
+i2c = board.I2C()
+# To create I2C bus on specific pins
+#import busio
+# i2c = busio.I2C(board.GP1, board.GP0)    # Pi Pico RP2040
+
+set(255, 255, 255)
+print("client starting")
+while not i2c.try_lock():
+    pass
+print("client has lock")
+set(0, 0, 255)
+
+
+def test_client():
+    try:
+        i2c.writeto(ADDRESS, bytes(103))  # 103 = 'g'
+        set(255, 0, 255)
+    except Exception as e:
+        print('exception on write: ' + str(e))
+        set(255, 0, 0)
+
+    result = bytearray(1)
+    try:
+        i2c.readfrom_into(ADDRESS, result)
+        print("client got answer: %d" % result[0])
+    except Exception as e:
+        print('exception on read: ' + str(e))
+        set(255, 0, 0)
+
+    if result[0] == 103: set(0, 255, 0)
+    else: set(255, 255, 255)
+
+# ----------
+
+try:
+    print("I2C addresses found:",
+        [hex(device_address) for device_address in i2c.scan()])
+
+    while True:
+        test_client()
+        time.sleep(1)
+
+finally:
+    i2c.unlock()
+    print("unlocked")

--- a/i2c test server.py
+++ b/i2c test server.py
@@ -1,0 +1,57 @@
+'''I2CPeripheral test program
+
+** this requires firmware which includes the i2cperipheral library **
+
+opens up I2C server mode with address 42
+blinks the on-board neopixel blue on and off
+
+waits for the server to send a single byte, which should be a "g"
+this will change the neopixel to a solid green, indicating success.
+
+if the server asks for a byte, will respond with "c" if the server is initialized
+but hasn't received it's command yet, and "g" if it has.
+
+'''
+
+import time
+
+import board
+from i2cperipheral import I2CPeripheral
+
+import neopixel
+led = neopixel.NeoPixel(board.NEOPIXEL, 1)
+led.brightness = 0.3
+
+def set(r, g, b): led[0] = (r, g, b)
+
+mode = 'c'
+cycle = 0
+
+device = I2CPeripheral(board.SCL, board.SDA, (0x42, 0x43))
+print('peripheral registered')
+
+while True:
+    print('perf cycle, m=%s, c=%d' % (mode, cycle))
+    if mode == '0': set(0, 0, 0)
+    elif mode == 'g': set(0, 255, 0)
+    else:
+        cycle += 1
+        if cycle >= 2: cycle = 0
+        set(0, 0, 150 * cycle)
+
+    time.sleep(0.5)
+
+    r = device.request()
+    if not r: continue
+    with r:  # Closes the transfer if necessary by sending a NACK or feeding dummy bytes
+        print('got msg to addr %d' % r.address)
+
+        if r.is_read:
+            # Master is asking for data.
+            n = r.write(bytes(mode[0]))
+
+        else:
+            # Master is sending data.
+            b = r.read(1)
+            mode = str(b, 'ascii')
+            print('got new mode: %s' % mode)


### PR DESCRIPTION
These attempt to communicate with each other using low-level/raw I2C primitives.

(TODO for Ken: I really need to dig out an atmel-samd chip and verify this works.
 I'm sure I've got a suitable one somewhere...)

Anyway, the idea is that with these two loaded as code.py on two boards with their
I2C's connected, ideally both boards' on-board neopixels should turn green.